### PR TITLE
correctly use isSwift in schemaForObjectClass

### DIFF
--- a/Realm/RLMObjectSchema.mm
+++ b/Realm/RLMObjectSchema.mm
@@ -126,6 +126,9 @@ const Ivar RLMDummySwiftIvar = []() {
                          arrayByAddingObjectsFromArray:allProperties];
         cls = superClass;
         superClass = class_getSuperclass(superClass);
+        
+        NSString *clsName = NSStringFromClass(cls);
+        isSwift = [RLMSwiftSupport isSwiftClassName:clsName] || [cls isSubclassOfClass:s_swiftObjectClass];
     }
     NSArray *persistedProperties = [allProperties filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(RLMProperty *property, NSDictionary *) {
         return !RLMPropertyTypeIsComputed(property.type);


### PR DESCRIPTION
When class has a superClass other than RLMObjectBase
the isSwift-flag should be computed from the superClass 
rather than using the one from the class.